### PR TITLE
Updating to eslint v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "release": "npm run upgrade && npm run clean && npm test && npm run bump"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "devDependencies": {
     "@jsdevtools/version-bump-prompt": "^6.0.5",
@@ -39,20 +39,20 @@
     "@types/mocha": "^8.0.0",
     "@types/node": "^14.0.23",
     "chai": "^4.2.0",
-    "eslint": "^7.4.0",
+    "eslint": "^8.1.0",
     "mocha": "^8.0.1",
     "npm-check": "^5.9.0",
     "nyc": "^15.0.0",
     "shx": "^0.3.2",
     "source-map-support": "^0.5.12",
-    "typescript": "^3.5.1"
+    "typescript": "^4.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.6.1",
-    "@typescript-eslint/parser": "^3.6.1",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
     "eslint-plugin-jsdoc": "^30.0.3"
   },
   "peerDependencies": {
-    "eslint": ">=7"
+    "eslint": ">=8"
   }
 }


### PR DESCRIPTION
Trying to release swagger parser and getting this:

```
npm run lint

> @apidevtools/swagger-parser@10.0.3 lint
> eslint lib test online/src/js


Oops! Something went wrong! :(

ESLint: 8.4.0

TypeError: Failed to load parser '@typescript-eslint/parser' declared in '.eslintrc.yml » @jsdevtools/eslint-config#overrides[0]': Class extends value undefined is not a constructor or null
    at Object.<anonymous> (/Users/phil/src/swagger-parser/node_modules/@typescript-eslint/experimental-utils/dist/ts-eslint/CLIEngine.js:12:34)
    at Module._compile (/Users/phil/src/swagger-parser/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (/Users/phil/src/swagger-parser/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at Object.<anonymous> (/Users/phil/src/swagger-parser/node_modules/@typescript-eslint/experimental-utils/dist/ts-eslint/index.js:14:14)
    at Module._compile (/Users/phil/src/swagger-parser/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
```

According to StackOverflow I need to do this.

https://stackoverflow.com/questions/69513869/eslint-8-0-0-failed-to-load-plugin-typescript-eslint